### PR TITLE
one イベント時のバグ対策

### DIFF
--- a/src/event/eventdispatcher.js
+++ b/src/event/eventdispatcher.js
@@ -57,8 +57,9 @@ tm.event = tm.event || {};
             
             var listeners = this._listeners[e.type];
             if (listeners) {
-                for (var i=0,len=listeners.length; i<len; ++i) {
-                    listeners[i].call(this, e);
+                var temp = listeners.clone();
+                for (var i=0,len=temp.length; i<len; ++i) {
+                    temp[i].call(this, e);
                 }
             }
             

--- a/test/event/eventdispatcher.js
+++ b/test/event/eventdispatcher.js
@@ -1,0 +1,70 @@
+
+describe('tm.event.EventDispatcher', function() {
+    
+    it('init', function() {
+        var elm  = tm.event.EventDispatcher();
+    });
+    
+    it('on', function() {
+        var elm  = tm.event.EventDispatcher();
+        var flag = false;
+        elm.on("hoge", function() {
+        	flag = true;
+        });
+
+        var e = tm.event.Event("hoge");
+        elm.fire(e);
+
+        assert(flag === true);
+    });
+    
+    it('off', function() {
+        var elm  = tm.event.EventDispatcher();
+        var flag = false;
+        var func = function() {
+        	flag = true;
+        };
+        elm.on("hoge", func);
+        elm.off("hoge", func);
+
+        var e = tm.event.Event("hoge");
+        elm.fire(e);
+
+        assert(flag === false);
+    });
+
+    it('fire', function() {
+        var elm  = tm.event.EventDispatcher();
+        var num = 0;
+        var func = function() {
+        	++num;
+        };
+        elm.on("eventname", func);
+        elm.on("eventname", func);
+        elm.oneventname = func;
+
+        var e = tm.event.Event("eventname");
+        elm.fire(e);
+
+        assert(num === 3);
+    });
+
+    it('one', function() {
+    	var test = tm.event.EventDispatcher();
+    	var count = 0;
+    	var flags = [false, false, false, false, false];
+
+    	test.one("testevent", function() { count += 1; flags[0] = true; });
+    	test.one("testevent", function() { count += 1; flags[1] = true; });
+    	test.one("testevent", function() { count += 1; flags[2] = true; });
+    	test.one("testevent", function() { count += 1; flags[3] = true; });
+    	test.one("testevent", function() { count += 1; flags[4] = true; });
+
+    	test.fire( tm.event.Event("testevent") );
+
+    	assert(count === 5);
+    	assert(flags.equals([true, true, true, true, true]));
+    });
+
+});
+

--- a/test/index.html
+++ b/test/index.html
@@ -32,6 +32,8 @@
         <script src="core/string.js"></script>
         <script src="core/number.js"></script>
 
+        <script src="event/eventdispatcher.js"></script>
+
         <script src="util/type.js"></script>
         <script src="util/flow.js"></script>
 


### PR DESCRIPTION
### bug

one イベントだと内部でイベント配列の中身をいじってしまうので
fire 内のループがおかしくなる
### fix

fire 内のループをいったん clone してそっちでループをまわすようにする
