### PR TITLE
multi tileset support.

### DIFF
--- a/src/asset/mapsheet.js
+++ b/src/asset/mapsheet.js
@@ -184,6 +184,9 @@
         _propertiesToJson: function(elm) {
             var properties = elm.getElementsByTagName("properties")[0];
             var obj = {};
+            if (properties === undefined) {
+                return obj;
+            }
             for (var k = 0;k < properties.childNodes.length;k++) {
                 var p = properties.childNodes[k];
                 if (p.tagName === "property") {


### PR DESCRIPTION
#122 の対応のために、まず、tmx で複数のタイルセットを使用した場合にちゃんと表示できるように修正。

_buildTilesets メソッドで、MapSheet の tilesets から、１つのタイルセットとして使えるように
情報をあつめてから、レイヤーを描画するようにしました。ちょっと実装に悩みつつ…

それと、google group　にあがってた、properties が無い場合に読み込めないバグの対処。
