### PR TITLE
fromJSONが正しく動作しない

### DIFF
--- a/src/app/element.js
+++ b/src/app/element.js
@@ -194,14 +194,14 @@ tm.app = tm.app || {};
                 if (key == "children") {
                     if (value instanceof Array) {
                         for (var i=0,len=value.length; i<len; ++i) {
-                            var data = value[i];
-                            _fromJSON(data.name, data);
+                            var childData = value[i];
+                            _fromJSON(childData.name, childData);
                         }
                     }
                     else {
                         for (var key in value) {
-                            var data = value[key];
-                            _fromJSON(key, data);
+                            var childData = value[key];
+                            _fromJSON(key, childData);
                         }
                     }
                 }


### PR DESCRIPTION
お疲れ様です。だいしです。

tm.app.ElementのfromJSONメソッド、超便利なのでいつも使わせてもらってます。

さて、このメソッドがどうもバグっているようです。
childrenプロパティを最後に配置しなかった場合、以降のプロパティにundefinedが代入されます。

再現コードをrunstantに書いたのでご確認ください。

http://goo.gl/HMHDtR

修正差分をpullReqしますので、問題ないようでしたらmergeお願いします。
