### PR TITLE
windows8のタッチスクリーン&マウスイベント問題

### DIFF
--- a/src/app/baseapp.js
+++ b/src/app/baseapp.js
@@ -61,6 +61,12 @@ tm.app = tm.app || {};
             
             // ポインティングをセット(PC では Mouse, Mobile では Touch)
             this.pointing   = (tm.isMobile) ? this.touch : this.mouse;
+            this.element.addEventListener("touchstart", function () {
+                this.pointing = this.touch;
+            }.bind(this));
+            this.element.addEventListener("mousedown", function () {
+                this.pointing = this.mouse;
+            }.bind(this));
             
             // 加速度センサーを生成
             this.accelerometer = tm.input.Accelerometer();


### PR DESCRIPTION
タッチ(or クリック)する度に`tm.app.BaseApp`の`pointing`を切り替えるようにしています。
そのため、タッチとクリック同時判定はできませんが、途中で切り替わっても対応できます。
