### PR TITLE
Webフレームワーク『Meteor』でtmlibを利用すると、エラーになる

### DIFF
--- a/src/tmlib.js
+++ b/src/tmlib.js
@@ -6,6 +6,7 @@
  */
 var tm = tm || {};
 tm.global = window || global || this;
+tm.global.tm = tm;
 
 // node.js
 if (typeof module !== 'undefined' && module.exports) {

--- a/src/tmlib.js
+++ b/src/tmlib.js
@@ -6,7 +6,9 @@
  */
 var tm = tm || {};
 tm.global = window || global || this;
-tm.global.tm = tm;
+if (tm.global.Meteor != null) {
+  tm.global.tm = tm;
+}
 
 // node.js
 if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
いつもお世話になっております。エマ・デュランダルです。

最近、Meteorで開発しているんですが、Meteorでtmlibを使おうとすると、
windowオブジェクトにtmオブジェクトが追加されずに、エラーになります。

原因は、Meteorが個々のJSファイルを読み込む際に、

``` javascript
(function(){/*
 * tmlib.js 0.4.1
 * http://github.com/phi-jp/tmlib.js
 * MIT Licensed
 * 
 * Copyright (C) 2010 phi, http://tmlife.net
 */

(function() { "use strict"; })();

/*
 * tm namespace
 */
var tm = tm || {};
//var window = window || {};
tm.global = window || global || this;

// node.js
if (typeof module !== 'undefined' && module.exports) {

....

    tm.ui.LoadingScene = tm.scene.LoadingScene;

})();

})();
```

というように、全体を(function(){})();で囲ってしまうのが原因です。

スマートな対策かはちょっと自信ありませんが、

```
tm.global.tm = tm;
```

として動くようにしました。
問題なければ、マージしていただけますと幸いです。
