### PR TITLE
[MapSprite] Objectレイヤのwidth/heightにundefinedが入ってしまう

### DIFF
--- a/src/display/mapsprite.js
+++ b/src/display/mapsprite.js
@@ -173,8 +173,8 @@
             var self = this;
 
             var group = tm.display.CanvasElement().addChildTo(self);
-            group.width = layer.width;
-            group.height = layer.height;
+            group.width = self.width;
+            group.height = self.height;
 
             layer.objects.forEach(function(obj) {
                 var _class = tm.using(obj.type);


### PR DESCRIPTION
お疲れ様です。

TiledMapEditorで作成されたデータのobjectgroupレイヤにはwidth, heightが定義されていないため、オブジェクト構築中にlayerのwidth, heightにundefinedが代入されてしまい、以降localToGobal等が正常に動作しなくなっています。
objectgroupレイヤにはマップ自体の幅・高さを設定するように修正しました。

よろしくお願いします。
