### PR TITLE
support image-layer by tiled map editor

### DIFF
--- a/src/display/mapsprite.js
+++ b/src/display/mapsprite.js
@@ -62,6 +62,9 @@
                 if (layer.type == "objectgroup") {
                     self._buildObject(layer);
                 }
+                else if (layer.type == "imagelayer") {
+                    self._buildImageLayer(layer);
+                }
                 else {
                     self._buildLayer(layer);
                 }
@@ -205,6 +208,19 @@
             self[layer.name] = group;
 
         },
+
+        /**
+         * @private
+         */
+        _buildImageLayer: function(layer) {
+            var sprite = tm.display.Sprite(layer.image.source).setOrigin(0, 0).addChildTo(this);
+            sprite.x = layer.x;
+            sprite.y = layer.y;
+            sprite.alpha = layer.alpha;
+            sprite.visible = layer.visible;
+
+            this[layer.name] = sprite;
+        }
 
     });
 


### PR DESCRIPTION
どもども。

Tiled Map Editorで作成したマップの「画像レイヤー」を再現するために、MapSheetとMapSpriteを拡張しました。
ご確認ください。
