### PR TITLE
WebAudioのメモリリーク対策

### DIFF
--- a/src/sound/webaudio.js
+++ b/src/sound/webaudio.js
@@ -230,12 +230,13 @@ tm.sound = tm.sound || {};
         _setup: function() {
             this.source     = this.context.createBufferSource();
             this.gainNode   = this.context.createGain();
-            this.panner     = this.context.createPanner();
+            // this.panner     = this.context.createPanner();
             this.analyser   = this.context.createAnalyser();
 
             this.source.connect(this.gainNode);
-            this.gainNode.connect(this.panner);
-            this.panner.connect(this.analyser);
+            // this.gainNode.connect(this.panner);
+            // this.panner.connect(this.analyser);
+            this.gainNode.connect(this.analyser);
             this.analyser.connect(this.context.destination);
 
             // TODO 暫定的対応


### PR DESCRIPTION
単純にPannerNodeを挿入しないように修正したものです。
いつかブラウザ側のバグが直った時に元に戻せるように、コメントアウトだけ。
