### PR TITLE
fix tm.app.Element.prototype.fromJSON.

### DIFF
--- a/src/app/element.js
+++ b/src/app/element.js
@@ -190,10 +190,12 @@ tm.app = tm.app || {};
                 
                 console.assert(Object.keys(_class).length !== 0, _class + " is not defined.");
                 
-                var elm = _class.apply(null, args).addChildTo(this);
+                var elm = _class.apply(null, args);
                 elm.fromJSON(data);
                 
                 this[name] = elm;
+                
+                elm.addChildTo(this);
             }.bind(this);
             
             for (var key in data) {


### PR DESCRIPTION
fromJSONでchildrenに子要素を追加する際、addChildToを子要素の生成が完了した後に行うよう修正しました。

子要素にonaddedプロパティを定義していた場合でも問題なく実行されるようになります。
