### PR TITLE
Update Copyright URL

### DIFF
--- a/build/tmlib.js
+++ b/build/tmlib.js
@@ -3,7 +3,7 @@
  * http://github.com/phi-jp/tmlib.js
  * MIT Licensed
  * 
- * Copyright (C) 2010 phi, http://tmlife.net
+ * Copyright (C) 2010 phi, https://phiary.me/
  */
 
 (function() { "use strict"; })();


### PR DESCRIPTION
元のURLはドメインが切れたのか変なサイトに飛ばされるので変えた方が良いかも？